### PR TITLE
Feature/BBL-263 | vpce s3 bucket policy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.5
+MAKEFILES_VER := v0.1.12
+PROJECT_SHORT := bb
 
 help:
 	@echo 'Available Commands:'
@@ -19,5 +20,5 @@ init-makefiles: ## initialize makefiles
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk
--include ${MAKEFILES_DIR}/terraform13/terraform13.mk
--include ${MAKEFILES_DIR}/terratest13/terratest13.mk
+-include ${MAKEFILES_DIR}/terraform14/terraform14.mk
+-include ${MAKEFILES_DIR}/terratest14/terratest14.mk

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We have a tfstate S3 Bucket per account
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `false` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| vpc\_id | VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket. | `string` | `""` | no |
+| vpc\_ids\_list | VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket. | `list(string)` | `[]` | no |
 | write\_capacity | DynamoDB write capacity units | `number` | `5` | no |
 
 ## Outputs
@@ -143,6 +143,36 @@ module "terraform_state_backend" {
 
 ---
 
+## Important consideration
+When using the `enforce_vpc_requests = true` please consider the following 
+[AWS VPC gateway endpoint limitations](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html#vpc-endpoints-limitations)
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| enforce\_vpc\_requests | Enable/Disable VPC endpoint for S3 bucket | `bool` | `false` | no |
+| vpc\_ids\_list | VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket. | `list(string)` | `[]` | no |
+
+
+#### To use gateway endpoints, you need to be aware of the current limitations:
+
+- You cannot use an AWS prefix list ID in an outbound rule in a network ACL to allow or deny outbound traffic
+ to the service specified in an endpoint. If your network ACL rules restrict traffic, you must specify the CIDR
+ block (IP address range) for the service instead. You can, however, use an AWS prefix list ID in an outbound
+ security group rule. For more information, see Security groups.
+- Endpoints are supported within the same Region only. You cannot create an endpoint between a VPC and a
+  service in a different Region.
+- Endpoints support IPv4 traffic only.
+- You cannot transfer an endpoint from one VPC to another, or from one service to another.
+- You have a quota on the number of endpoints you can create per VPC. For more information, see VPC endpoints.
+- Endpoint connections cannot be extended out of a VPC. Resources on the other side of a VPN connection,
+ VPC peering connection, transit gateway, AWS Direct Connect connection, or ClassicLink connection in your VPC
+ cannot use the endpoint to communicate with resources in the endpoint service.
+- You must enable DNS resolution in your VPC, or if you're using your own DNS server, ensure that
+ DNS requests to the required service (such as Amazon S3) are resolved correctly to the IP addresses
+ maintained by AWS. For more information, see Using DNS with your VPC and AWS IP Address Ranges in the
+ Amazon Web Services General Reference.
+
+Review the service-specific limits for your endpoint service.
 ## Binbash Leverage | DevOps Automation Code Library Integration
 
 In order to get the full automated potential of the

--- a/README.md
+++ b/README.md
@@ -169,10 +169,8 @@ When using the `enforce_vpc_requests = true` please consider the following
  cannot use the endpoint to communicate with resources in the endpoint service.
 - You must enable DNS resolution in your VPC, or if you're using your own DNS server, ensure that
  DNS requests to the required service (such as Amazon S3) are resolved correctly to the IP addresses
- maintained by AWS. For more information, see Using DNS with your VPC and AWS IP Address Ranges in the
- Amazon Web Services General Reference.
+ maintained by AWS.
 
-Review the service-specific limits for your endpoint service.
 ## Binbash Leverage | DevOps Automation Code Library Integration
 
 In order to get the full automated potential of the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We have a tfstate S3 Bucket per account
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.28 |
+| terraform | >= 0.14.2 |
 | aws | ~> 3.0 |
 
 ## Providers
@@ -59,6 +59,7 @@ We have a tfstate S3 Bucket per account
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | enable\_server\_side\_encryption | Enable DynamoDB server-side encryption | `bool` | `true` | no |
 | enforce\_ssl\_requests | Enable/Disable replica for S3 bucket (for cross region replication purpose) | `bool` | `false` | no |
+| enforce\_vpc\_requests | Enable/Disable VPC endpoint for S3 bucket | `bool` | `false` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | force\_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |
@@ -71,6 +72,7 @@ We have a tfstate S3 Bucket per account
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `false` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| vpc\_id | VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket. | `string` | `""` | no |
 | write\_capacity | DynamoDB write capacity units | `number` | `5` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ When using the `enforce_vpc_requests = true` please consider the following
 | vpc\_ids\_list | VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket. | `list(string)` | `[]` | no |
 
 
-#### To use gateway endpoints, you need to be aware of the current limitations:
+#### To use gateway endpoints, you need to be aware of the current limitations
 
 - You cannot use an AWS prefix list ID in an outbound rule in a network ACL to allow or deny outbound traffic
  to the service specified in an endpoint. If your network ACL rules restrict traffic, you must specify the CIDR

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We have a tfstate S3 Bucket per account
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.14.2 |
+| terraform | >= 0.13.2 |
 | aws | ~> 3.0 |
 
 ## Providers
@@ -144,7 +144,7 @@ module "terraform_state_backend" {
 ---
 
 ## Important consideration
-When using the `enforce_vpc_requests = true` please consider the following 
+When using the `enforce_vpc_requests = true` please consider the following
 [AWS VPC gateway endpoint limitations](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html#vpc-endpoints-limitations)
 
 | Name | Description | Type | Default | Required |

--- a/examples/s3-tfstate-backend-crr-ssl/config.tf
+++ b/examples/s3-tfstate-backend-crr-ssl/config.tf
@@ -3,18 +3,16 @@
 #=============================#
 provider "aws" {
   alias                   = "main_region"
-  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
-  version                 = "~> 3.0"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 variable "region" {
@@ -35,16 +33,13 @@ variable "profile" {
   default     = "bb-dev-deploymaster"
 }
 
-# Uncomment for local testing
-//variable "profile" {
-//  type        = string
-//  description = "AWS Profile"
-//  default     = "bb-apps-devstg-devops"
-//}
-
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.12.28"
+  required_version = ">= 0.14.2"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
 }

--- a/examples/s3-tfstate-backend-crr-vpce/README.md
+++ b/examples/s3-tfstate-backend-crr-vpce/README.md
@@ -1,0 +1,69 @@
+# Terraform Module: Terraform Backend
+## Overview
+Terraform module to provision an S3 bucket to store terraform.tfstate file and a
+DynamoDB table to lock the state file to prevent concurrent modifications and state corruption.
+
+## Releases
+- **Versions:** `<= 0.x.y` (Terraform 0.11.x compatible)
+    - eg: https://registry.terraform.io/modules/binbashar/ec2-jenkins-vault/aws/0.0.1
+
+- **Versions:** `>= 1.x.y` (Terraform 0.12.x compatible -> **WIP**)
+    - eg: https://registry.terraform.io/modules/binbashar/ec2-jenkins-vault/aws/1.0.0
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.28 |
+| aws | ~> 2.70 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws.main\_region | ~> 2.70 |
+| aws.secondary\_region | ~> 2.70 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| acl | The canned ACL to apply to the S3 bucket | `string` | `"private"` | no |
+| additional\_tag\_map | Additional tags for appending to each tag map | `map(string)` | `{}` | no |
+| attributes | Additional attributes (e.g. `state`) | `list(string)` | <pre>[<br>  "state"<br>]</pre> | no |
+| block\_public\_acls | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `false` | no |
+| block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
+| bucket\_replication\_enabled | Enable/Disable replica for S3 bucket (for cross region replication purpose) | `bool` | `false` | no |
+| context | Default context to use for passing state between label invocations | `map(string)` | `{}` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| enable\_server\_side\_encryption | Enable DynamoDB server-side encryption | `bool` | `true` | no |
+| enforce\_ssl\_requests | Enable/Disable replica for S3 bucket (for cross region replication purpose) | `bool` | `false` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| force\_destroy | A boolean that indicates the S3 bucket can be destroyed even if it contains objects. These objects are not recoverable | `bool` | `false` | no |
+| ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |
+| label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
+| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `false` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `"terraform"` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| read\_capacity | DynamoDB read capacity units | `number` | `5` | no |
+| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | `string` | `"/[^a-zA-Z0-9-]/"` | no |
+| region | AWS Region the S3 bucket should reside in | `string` | n/a | yes |
+| restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `false` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| write\_capacity | DynamoDB write capacity units | `number` | `5` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dynamodb\_table\_arn | DynamoDB table ARN |
+| dynamodb\_table\_id | DynamoDB table ID |
+| dynamodb\_table\_name | DynamoDB table name |
+| s3\_bucket\_arn | S3 bucket ARN |
+| s3\_bucket\_domain\_name | S3 bucket domain name |
+| s3\_bucket\_id | S3 bucket ID |
+
+## Usage
+
+Check this example code as reference usage.

--- a/examples/s3-tfstate-backend-crr-vpce/config.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/config.tf
@@ -1,0 +1,45 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+provider "aws" {
+  alias                   = "main_region"
+  region                  = var.region
+  profile                 = var.profile
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
+}
+
+provider "aws" {
+  alias                   = "secondary_region"
+  region                  = var.region_secondary
+  profile                 = var.profile
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS Region"
+  default     = "us-east-1"
+}
+
+variable "region_secondary" {
+  type        = string
+  description = "AWS secondary Region the S3 replication bucket should reside in"
+  default     = "us-east-2"
+}
+
+variable "profile" {
+  type        = string
+  description = "AWS Profile"
+  default     = "bb-shared-deploymaster"
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = ">= 0.14.2"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
+}

--- a/examples/s3-tfstate-backend-crr-vpce/locals.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/locals.tf
@@ -1,0 +1,30 @@
+locals {
+  tags = {
+    Name        = "infra-tfstate-backend-test"
+    Terraform   = "true"
+    Environment = var.environment
+  }
+
+  # Network Local Vars
+  # https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
+  # Important
+  # Docker runs in the 172.17.0.0/16 CIDR range in Amazon EKS clusters. We recommend that your cluster's VPC subnets do
+  # not overlap this range. Otherwise, you will receive the following error:
+  # Error: : error upgrading connection: error dialing backend: dial tcp 172.17.nn.nn:10250: getsockopt: no route to host
+  vpc_name       = "${var.namespace}-${var.environment}-vpc"
+  vpc_cidr_block = "172.24.0.0/20"
+  azs = [
+    "${var.region}a",
+    "${var.region}b"
+  ]
+
+  private_subnets = [
+    "172.24.0.0/23",
+    "172.24.2.0/23",
+  ]
+
+  public_subnets = [
+    "172.24.6.0/23",
+    "172.24.8.0/23",
+  ]
+}

--- a/examples/s3-tfstate-backend-crr-vpce/main.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/main.tf
@@ -1,0 +1,37 @@
+module "terraform_state_backend" {
+  source                        = "../../"
+  namespace                     = var.namespace
+  environment                   = var.environment
+  stage                         = var.stage
+  name                          = var.name
+  attributes                    = var.attributes
+  bucket_replication_enabled    = var.bucket_replication_enabled
+  acl                           = var.acl
+  block_public_acls             = var.block_public_acls
+  block_public_policy           = var.block_public_policy
+  enable_server_side_encryption = var.enable_server_side_encryption
+  restrict_public_buckets       = var.restrict_public_buckets
+  enforce_ssl_requests          = var.enforce_ssl_requests
+  enforce_vpc_requests          = var.enforce_vpc_requests
+  tags                          = var.tags
+
+  providers = {
+    aws.main_region      = aws.main_region
+    aws.secondary_region = aws.secondary_region
+  }
+}
+
+#
+# Configuring VPC Endpoint for S3 to be accessible from our private subnet
+# without needing a NAT gateway.
+#
+resource "aws_vpc_endpoint" "s3" {
+  provider          = aws.main_region
+  vpc_id            = var.vpc_id
+  vpc_endpoint_type = "Gateway"
+
+  service_name      = "com.amazonaws.${var.region}.s3"
+
+  route_table_ids = var.vpc_route_table_ids_list
+}
+

--- a/examples/s3-tfstate-backend-crr-vpce/main.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/main.tf
@@ -13,6 +13,7 @@ module "terraform_state_backend" {
   restrict_public_buckets       = var.restrict_public_buckets
   enforce_ssl_requests          = var.enforce_ssl_requests
   enforce_vpc_requests          = var.enforce_vpc_requests
+  vpc_ids_list                  = var.vpc_ids_list
   tags                          = var.tags
 
   providers = {
@@ -27,7 +28,7 @@ module "terraform_state_backend" {
 #
 resource "aws_vpc_endpoint" "s3" {
   provider          = aws.main_region
-  vpc_id            = var.vpc_id
+  vpc_id            = var.vpc_id_vpce
   vpc_endpoint_type = "Gateway"
 
   service_name = "com.amazonaws.${var.region}.s3"

--- a/examples/s3-tfstate-backend-crr-vpce/main.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/main.tf
@@ -30,7 +30,7 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id            = var.vpc_id
   vpc_endpoint_type = "Gateway"
 
-  service_name      = "com.amazonaws.${var.region}.s3"
+  service_name = "com.amazonaws.${var.region}.s3"
 
   route_table_ids = var.vpc_route_table_ids_list
 }

--- a/examples/s3-tfstate-backend-crr-vpce/outputs.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_bucket_id" {
+  value       = module.terraform_state_backend.s3_bucket_id
+  description = "S3 bucket ID"
+}
+
+output "dynamodb_table_name" {
+  value       = module.terraform_state_backend.dynamodb_table_name
+  description = "DynamoDB table name"
+}

--- a/examples/s3-tfstate-backend-crr-vpce/variables.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/variables.tf
@@ -92,10 +92,15 @@ variable "enforce_vpc_requests" {
   default     = true
 }
 
-variable "vpc_id" {
+variable "vpc_id_vpce" {
   type        = string
   description = "VPC id"
   default     = "vpc-02ed8f213c7b6d869"
+}
+variable "vpc_ids_list" {
+  type        = list(string)
+  description = "VPC id"
+  default     = ["vpc-02ed8f213c7b6d869"]
 }
 
 variable "vpc_route_table_ids_list" {

--- a/examples/s3-tfstate-backend-crr-vpce/variables.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/variables.tf
@@ -1,0 +1,107 @@
+#==============================#
+# Tf-state S3 Backend          #
+#==============================#
+variable "namespace" {
+  type        = string
+  default     = "bb"
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = "qa"
+  description = "Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = "test"
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = "terraform-crr-vpce"
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = ["state"]
+  description = "Additional attributes (e.g. `state`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+
+variable "acl" {
+  type        = string
+  description = "The canned ACL to apply to the S3 bucket"
+  default     = "private"
+}
+
+variable "enable_server_side_encryption" {
+  type        = bool
+  description = "Enable DynamoDB server-side encryption"
+  default     = true
+}
+
+variable "block_public_acls" {
+  type        = bool
+  description = "Whether Amazon S3 should block public ACLs for this bucket."
+  default     = true
+}
+
+variable "block_public_policy" {
+  type        = bool
+  description = "Whether Amazon S3 should block public bucket policies for this bucket."
+  default     = true
+}
+
+variable "restrict_public_buckets" {
+  type        = bool
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
+  default     = true
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = "/[^a-zA-Z0-9-]/"
+  description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
+}
+
+variable "bucket_replication_enabled" {
+  type        = bool
+  description = "Enable/Disable replica for S3 bucket (for cross region replication purpose)"
+  default     = true
+}
+
+variable "enforce_ssl_requests" {
+  type        = bool
+  description = "Enable/Disable replica for S3 bucket (for cross region replication purpose)"
+  default     = false
+}
+
+variable "enforce_vpc_requests" {
+  type        = bool
+  description = "Enable/Disable VPC endpoint for S3 bucket"
+  default     = true
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC id"
+  default     = "vpc-02ed8f213c7b6d869"
+}
+
+variable "vpc_route_table_ids_list" {
+  type        = list(string)
+  description = "VPC route table ids"
+  default     = ["rtb-0dfa681c27e8b33f5","rtb-095aed0b9abf62536"]
+}
+
+

--- a/examples/s3-tfstate-backend-crr-vpce/variables.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/variables.tf
@@ -101,7 +101,7 @@ variable "vpc_id" {
 variable "vpc_route_table_ids_list" {
   type        = list(string)
   description = "VPC route table ids"
-  default     = ["rtb-0dfa681c27e8b33f5","rtb-095aed0b9abf62536"]
+  default     = ["rtb-0dfa681c27e8b33f5", "rtb-095aed0b9abf62536"]
 }
 
 

--- a/examples/s3-tfstate-backend-crr/config.tf
+++ b/examples/s3-tfstate-backend-crr/config.tf
@@ -3,18 +3,16 @@
 #=============================#
 provider "aws" {
   alias                   = "main_region"
-  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
-  version                 = "~> 3.0"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 variable "region" {
@@ -35,16 +33,13 @@ variable "profile" {
   default     = "bb-dev-deploymaster"
 }
 
-# Uncomment for local testing
-//variable "profile" {
-//  type        = string
-//  description = "AWS Profile"
-//  default     = "bb-apps-devstg-devops"
-//}
-
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.12.28"
+  required_version = ">= 0.14.2"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
 }

--- a/examples/s3-tfstate-backend/config.tf
+++ b/examples/s3-tfstate-backend/config.tf
@@ -3,18 +3,16 @@
 #=============================#
 provider "aws" {
   alias                   = "main_region"
-  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
-  version                 = "~> 3.0"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  shared_credentials_file = "~/.aws/${var.namespace}/config"
 }
 
 variable "region" {
@@ -35,16 +33,13 @@ variable "profile" {
   default     = "bb-dev-deploymaster"
 }
 
-# Uncomment for local testing
-//variable "profile" {
-//  type        = string
-//  description = "AWS Profile"
-//  default     = "bb-apps-devstg-devops"
-//}
-
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.12.28"
+  required_version = ">= 0.14.2"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -109,30 +109,3 @@ resource "aws_dynamodb_table" "without_server_side_encryption" {
     Environment = var.stage
   }
 }
-
-resource "aws_s3_bucket_policy" "default" {
-  count = var.enforce_ssl_requests ? 1 : 0
-
-  provider = aws.main_region
-  bucket   = aws_s3_bucket.default.id
-  policy   = <<POLICY
-{
-  "Id": "TerraformStateBucketPolicies",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EnforceSSlRequestsOnly",
-      "Action": "s3:*",
-      "Effect": "Deny",
-      "Resource": "${aws_s3_bucket.default.arn}/*",
-      "Condition": {
-         "Bool": {
-           "aws:SecureTransport": "false"
-          }
-      },
-      "Principal": "*"
-    }
-  ]
-}
-POLICY
-}

--- a/policy.tf
+++ b/policy.tf
@@ -1,0 +1,56 @@
+resource "aws_s3_bucket_policy" "default" {
+  count = var.enforce_ssl_requests ? 1 : 0
+
+  provider = aws.main_region
+  bucket   = aws_s3_bucket.default.id
+  policy   = <<POLICY
+{
+  "Id": "TerraformStateBucketPolicySSL",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnforceSSlRequestsOnly",
+      "Action": "s3:*",
+      "Effect": "Deny",
+      "Resource": "${aws_s3_bucket.default.arn}/*",
+      "Condition": {
+         "Bool": {
+           "aws:SecureTransport": "false"
+          }
+      },
+      "Principal": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket_policy" "allow_vpc" {
+  count = var.enforce_vpc_requests && var.vpc_id !="" ? 1 : 0
+
+  provider = aws.main_region
+  bucket   = aws_s3_bucket.default.id
+  policy   = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "TerraformStateBucketPolicySllVpce",
+  "Statement": [
+    {
+      "Sid": "EnforceVPCeRequestsOnly",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "${aws_s3_bucket.default.arn}",
+        "${aws_s3_bucket.default.arn}/*"
+      ],
+      "Condition": {
+        "StringNotEquals": {
+          "aws:sourceVpc": "${var.vpc_id}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/policy.tf
+++ b/policy.tf
@@ -26,7 +26,7 @@ POLICY
 }
 
 resource "aws_s3_bucket_policy" "allow_vpc" {
-  count = var.enforce_vpc_requests && var.vpc_id !="" ? 1 : 0
+  count = var.enforce_vpc_requests && var.vpc_id != "" ? 1 : 0
 
   provider = aws.main_region
   bucket   = aws_s3_bucket.default.id

--- a/policy.tf
+++ b/policy.tf
@@ -2,8 +2,8 @@ resource "aws_s3_bucket_policy" "default" {
   count = var.enforce_ssl_requests ? 1 : 0
 
   provider = aws.main_region
-  bucket = aws_s3_bucket.default.id
-  policy = data.aws_iam_policy_document.default-ssl.json
+  bucket   = aws_s3_bucket.default.id
+  policy   = data.aws_iam_policy_document.default-ssl.json
 }
 
 data "aws_iam_policy_document" "default-ssl" {
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_policy" "default-ssl-vpc" {
   count = var.enforce_ssl_requests && var.enforce_vpc_requests && var.vpc_ids_list != [] ? 1 : 0
 
   provider = aws.main_region
-  bucket = aws_s3_bucket.default.id
+  bucket   = aws_s3_bucket.default.id
 
 
   policy = data.aws_iam_policy_document.default-ssl-vpc.json
@@ -105,11 +105,11 @@ data "aws_iam_policy_document" "default-ssl-vpc" {
     # aws:sourceVpc condition.
     #
     condition {
-      test = "StringNotEquals"
+      test     = "StringNotEquals"
       variable = "aws:sourceVpc"
       values = [
-      for vpc_id in var.vpc_ids_list:
-      vpc_id
+        for vpc_id in var.vpc_ids_list :
+        vpc_id
       ]
     }
   }

--- a/policy.tf
+++ b/policy.tf
@@ -33,10 +33,10 @@ resource "aws_s3_bucket_policy" "allow_vpc" {
   policy   = <<POLICY
 {
   "Version": "2012-10-17",
-  "Id": "TerraformStateBucketPolicySllVpce",
+  "Id": "TerraformStateBucketPolicySllVpc",
   "Statement": [
     {
-      "Sid": "EnforceVPCeRequestsOnly",
+      "Sid": "EnforceVPCRequestsOnly",
       "Effect": "Deny",
       "Principal": "*",
       "Action": "s3:*",

--- a/tests/verify_output_test.go
+++ b/tests/verify_output_test.go
@@ -61,32 +61,32 @@ func TestReplicatedBucketAndTableExist(t *testing.T) {
     assert.Equal(t, expectedDynamoDbTableName, actualDynamoDbTableName)
 }
 
-func TestReplicatedBucketAndTableExistVpceEnforced(t *testing.T) {
-    expectedBucketName        := "bb-test-terraform-crr-vpce"
-    expectedDynamoDbTableName := "bb-test-terraform-crr-vpce"
-
-    terraformOptions := &terraform.Options {
-        // The path to where our Terraform code is located
-        TerraformDir: "../examples/s3-tfstate-backend-crr-vpce",
-
-        // Disable colors in Terraform commands so its easier to parse stdout/stderr
-        NoColor: true,
-    }
-
-    // At the end of the test, run `terraform destroy` to clean up any resources that were created
-    defer terraform.Destroy(t, terraformOptions)
-
-    // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-    terraform.InitAndApply(t, terraformOptions)
-
-    // Run `terraform output` to get the values of output variables
-    actualBucketName        := terraform.Output(t, terraformOptions, "s3_bucket_id")
-    actualDynamoDbTableName := terraform.Output(t, terraformOptions, "dynamodb_table_name")
-
-    // Verify we're getting back the outputs we expect
-    assert.Equal(t, expectedBucketName, actualBucketName)
-    assert.Equal(t, expectedDynamoDbTableName, actualDynamoDbTableName)
-}
+// func TestReplicatedBucketAndTableExistVpceEnforced(t *testing.T) {
+//     expectedBucketName        := "bb-test-terraform-crr-vpce"
+//     expectedDynamoDbTableName := "bb-test-terraform-crr-vpce"
+//
+//     terraformOptions := &terraform.Options {
+//         // The path to where our Terraform code is located
+//         TerraformDir: "../examples/s3-tfstate-backend-crr-vpce",
+//
+//         // Disable colors in Terraform commands so its easier to parse stdout/stderr
+//         NoColor: true,
+//     }
+//
+//     // At the end of the test, run `terraform destroy` to clean up any resources that were created
+//     defer terraform.Destroy(t, terraformOptions)
+//
+//     // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+//     terraform.InitAndApply(t, terraformOptions)
+//
+//     // Run `terraform output` to get the values of output variables
+//     actualBucketName        := terraform.Output(t, terraformOptions, "s3_bucket_id")
+//     actualDynamoDbTableName := terraform.Output(t, terraformOptions, "dynamodb_table_name")
+//
+//     // Verify we're getting back the outputs we expect
+//     assert.Equal(t, expectedBucketName, actualBucketName)
+//     assert.Equal(t, expectedDynamoDbTableName, actualDynamoDbTableName)
+// }
 
 // func TestReplicatedBucketAndTableExistSslEnforced(t *testing.T) {
 //     expectedBucketName        := "bb-test-terraform-crr-ssl"

--- a/tests/verify_output_test.go
+++ b/tests/verify_output_test.go
@@ -61,6 +61,33 @@ func TestReplicatedBucketAndTableExist(t *testing.T) {
     assert.Equal(t, expectedDynamoDbTableName, actualDynamoDbTableName)
 }
 
+func TestReplicatedBucketAndTableExistVpceEnforced(t *testing.T) {
+    expectedBucketName        := "bb-test-terraform-crr-vpce"
+    expectedDynamoDbTableName := "bb-test-terraform-crr-vpce"
+
+    terraformOptions := &terraform.Options {
+        // The path to where our Terraform code is located
+        TerraformDir: "../examples/s3-tfstate-backend-crr-vpce",
+
+        // Disable colors in Terraform commands so its easier to parse stdout/stderr
+        NoColor: true,
+    }
+
+    // At the end of the test, run `terraform destroy` to clean up any resources that were created
+    defer terraform.Destroy(t, terraformOptions)
+
+    // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+    terraform.InitAndApply(t, terraformOptions)
+
+    // Run `terraform output` to get the values of output variables
+    actualBucketName        := terraform.Output(t, terraformOptions, "s3_bucket_id")
+    actualDynamoDbTableName := terraform.Output(t, terraformOptions, "dynamodb_table_name")
+
+    // Verify we're getting back the outputs we expect
+    assert.Equal(t, expectedBucketName, actualBucketName)
+    assert.Equal(t, expectedDynamoDbTableName, actualDynamoDbTableName)
+}
+
 // func TestReplicatedBucketAndTableExistSslEnforced(t *testing.T) {
 //     expectedBucketName        := "bb-test-terraform-crr-ssl"
 //     expectedDynamoDbTableName := "bb-test-terraform-crr-ssl"

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,16 @@ variable "enforce_ssl_requests" {
   description = "Enable/Disable replica for S3 bucket (for cross region replication purpose)"
   default     = false
 }
+
+variable "enforce_vpc_requests" {
+  type        = bool
+  description = "Enable/Disable VPC endpoint for S3 bucket"
+  default     = false
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket."
+  default     = ""
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -142,9 +142,9 @@ variable "enforce_vpc_requests" {
   default     = false
 }
 
-variable "vpc_id" {
-  type        = string
+variable "vpc_ids_list" {
+  type        = list(string)
   description = "VPC id to access the S3 bucket vía vpc endpoint. The VPCe must be in the same AWS Region as the bucket."
-  default     = ""
+  default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.14.2"
+  required_version = ">= 0.13.2"
 
   required_providers {
     aws = "~> 3.0"

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12.28"
+  required_version = ">= 0.14.2"
 
   required_providers {
     aws = "~> 3.0"


### PR DESCRIPTION
### Commits on Dec 16, 2020
- @exequielrafaela - BBL-263 | upgrading to terraform 0.14.2 - 669b539
- @exequielrafaela - BBL-263 | adding optional vpc filtering via bucket policy to enforce vpce access - 48bff00
- @exequielrafaela - BBL-263 | updating vpc filtering bucket policy ids - 74dee44
- @exequielrafaela - BBL-263 | updating examples config.tf to use terraform 0.14.2 - c9a0910
- @exequielrafaela - BBL-263 | adding crr-vpce test - b44f603
- @exequielrafaela - BBL-263 | applying make pre-commit to format and update README.md - a14b8ed

### Commits on Dec 18, 2020
- @exequielrafaela - BBL-263 | adding s3 service limited vpc traffic policy - b7847bc
- @exequielrafaela - BBL-263 | make pre-commit applied - terraform format + terraform docs + documentation vpce considerations added - 4ec2b12
- @exequielrafaela - BBL-263 | small readme.md update - 152afdb
- @exequielrafaela - BBL-263 | minor readme.md important consideration section sintaxt improvement - 59826e1
- @exequielrafaela - BBL-263 | requirement tf-0.13.2 tests implemented with tf-0.14.2 - 9317a0f