### PR TITLE
Add public access block to the replication bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
       - run:
           name: test-terraform-linting
-          command: make tflint-deep
+          command: make tflint
 
       - slack/notify:
           event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,10 @@ jobs:
             #
             # Install terraform-docs
             #sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
-            chmod +x ./terraform-docs
-            sudo mv ./terraform-docs /usr/local/bin/terraform-docs
+            curl -Lo terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz
+            tar xfz terraform-docs.tar.gz
+            chmod +x terraform-docs
+            sudo mv terraform-docs /usr/local/bin/
             #
       - run:
           name: test-terraform-format-and-docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             terraform --version
             #
             # Install terraform-docs
-            sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+            #sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
             curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             #
             # Install terraform-docs
             sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
+            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname | tr '[:upper:]' '[:lower:]')-amd64
             chmod +x ./terraform-docs
             sudo mv ./terraform-docs /usr/local/bin/terraform-docs
             #

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.2.1
+MAKEFILES_VER := v0.2.8
 PROJECT_SHORT := bb
 
 help:

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ We have a tfstate S3 Bucket per account
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.main_region"></a> [aws.main\_region](#provider\_aws.main\_region) | ~> 3.0 |
-| <a name="provider_aws.secondary_region"></a> [aws.secondary\_region](#provider\_aws.secondary\_region) | ~> 3.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | ~> 3.0 |
+| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | ~> 3.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
@@ -65,6 +65,7 @@ No modules.
 | [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.default-ssl-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.replication_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [time_sleep.wait_30_secs](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.default-ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default-ssl-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -23,6 +23,8 @@ resource "aws_s3_bucket" "replication_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+  count = var.bucket_replication_enabled ? 1 : 0
+  
   provider                = aws.secondary
   bucket                  = aws_s3_bucket.replication_bucket[0].id
   block_public_acls       = var.block_public_acls

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "replication_bucket" {
 
 resource "aws_s3_bucket_public_access_block" "replication_bucket" {
   count = var.bucket_replication_enabled ? 1 : 0
-  
+
   provider                = aws.secondary
   bucket                  = aws_s3_bucket.replication_bucket[0].id
   block_public_acls       = var.block_public_acls

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -22,6 +22,15 @@ resource "aws_s3_bucket" "replication_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+  provider                = aws.secondary
+  bucket                  = aws_s3_bucket.replication_bucket[0].id
+  block_public_acls       = var.block_public_acls
+  ignore_public_acls      = var.ignore_public_acls
+  block_public_policy     = var.block_public_policy
+  restrict_public_buckets = var.restrict_public_buckets
+}
+
 resource "aws_iam_role" "bucket_replication" {
   count = var.bucket_replication_enabled ? 1 : 0
 

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -29,6 +29,7 @@ resource "aws_s3_bucket_public_access_block" "replication_bucket" {
   ignore_public_acls      = var.ignore_public_acls
   block_public_policy     = var.block_public_policy
   restrict_public_buckets = var.restrict_public_buckets
+  depends_on              = [aws_s3_bucket.replication_bucket]
 }
 
 resource "aws_iam_role" "bucket_replication" {

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ resource "aws_s3_bucket_public_access_block" "default" {
   block_public_policy     = var.block_public_policy
   restrict_public_buckets = var.restrict_public_buckets
   depends_on              = [aws_s3_bucket.default]
-
 }
 
 resource "time_sleep" "wait_30_secs" {

--- a/policy.tf
+++ b/policy.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "default-ssl" {
 }
 
 resource "aws_s3_bucket_policy" "default-ssl-vpc" {
-  count = var.enforce_ssl_requests && var.enforce_vpc_requests && var.vpc_ids_list != [] ? 1 : 0
+  count = var.enforce_ssl_requests && var.enforce_vpc_requests && length(var.vpc_ids_list) != 0 ? 1 : 0
 
   provider   = aws.primary
   bucket     = aws_s3_bucket.default.id

--- a/tests/verify_output_test.go
+++ b/tests/verify_output_test.go
@@ -8,12 +8,17 @@ import (
 )
 
 func TestBucketAndTableExist(t *testing.T) {
-    expectedBucketName        := "bb-test-terraform"
-    expectedDynamoDbTableName := "bb-test-terraform"
+    expectedBucketName        := "bb-test-tfbackend-rand212"
+    expectedDynamoDbTableName := "bb-test-tfbackend-rand212"
 
     terraformOptions := &terraform.Options {
         // The path to where our Terraform code is located
         TerraformDir: "../examples/s3-tfstate-backend",
+
+        // Override variables
+        Vars: map[string]interface{} {
+            "name": "tfbackend-rand212",
+        },
 
         // Disable colors in Terraform commands so its easier to parse stdout/stderr
         NoColor: true,
@@ -35,12 +40,17 @@ func TestBucketAndTableExist(t *testing.T) {
 }
 
 func TestReplicatedBucketAndTableExist(t *testing.T) {
-    expectedBucketName        := "bb-test-terraform-crr"
-    expectedDynamoDbTableName := "bb-test-terraform-crr"
+    expectedBucketName        := "bb-test-tfbackend-crr-rand980"
+    expectedDynamoDbTableName := "bb-test-tfbackend-crr-rand980"
 
     terraformOptions := &terraform.Options {
         // The path to where our Terraform code is located
         TerraformDir: "../examples/s3-tfstate-backend-crr",
+
+        // Override variables
+        Vars: map[string]interface{} {
+            "name": "tfbackend-crr-rand980",
+        },
 
         // Disable colors in Terraform commands so its easier to parse stdout/stderr
         NoColor: true,


### PR DESCRIPTION
## what
* Add public access block to the replication bucket.

## why
* This was needed to be able to configure the replication bucket with a more secure baseline.

## references
* `closes #18`

