### PR TITLE
Upgrade provider version

### DIFF
--- a/examples/s3-tfstate-backend-crr-ssl/config.tf
+++ b/examples/s3-tfstate-backend-crr-ssl/config.tf
@@ -2,17 +2,15 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  alias                   = "main_region"
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "main_region"
+  region  = var.region
+  profile = var.profile
 }
 
 provider "aws" {
-  alias                   = "secondary_region"
-  region                  = var.region_secondary
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "secondary_region"
+  region  = var.region_secondary
+  profile = var.profile
 }
 
 variable "region" {
@@ -37,9 +35,9 @@ variable "profile" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/examples/s3-tfstate-backend-crr-vpce/config.tf
+++ b/examples/s3-tfstate-backend-crr-vpce/config.tf
@@ -2,17 +2,15 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  alias                   = "main_region"
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "main_region"
+  region  = var.region
+  profile = var.profile
 }
 
 provider "aws" {
-  alias                   = "secondary_region"
-  region                  = var.region_secondary
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "secondary_region"
+  region  = var.region_secondary
+  profile = var.profile
 }
 
 variable "region" {
@@ -37,9 +35,9 @@ variable "profile" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/examples/s3-tfstate-backend-crr/config.tf
+++ b/examples/s3-tfstate-backend-crr/config.tf
@@ -2,17 +2,15 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  alias                   = "main_region"
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "main_region"
+  region  = var.region
+  profile = var.profile
 }
 
 provider "aws" {
-  alias                   = "secondary_region"
-  region                  = var.region_secondary
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "secondary_region"
+  region  = var.region_secondary
+  profile = var.profile
 }
 
 variable "region" {
@@ -37,9 +35,9 @@ variable "profile" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/examples/s3-tfstate-backend/config.tf
+++ b/examples/s3-tfstate-backend/config.tf
@@ -2,17 +2,15 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  alias                   = "main_region"
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "main_region"
+  region  = var.region
+  profile = var.profile
 }
 
 provider "aws" {
-  alias                   = "secondary_region"
-  region                  = var.region_secondary
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.namespace}/config"
+  alias   = "secondary_region"
+  region  = var.region_secondary
+  profile = var.profile
 }
 
 variable "region" {
@@ -37,9 +35,9 @@ variable "profile" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 3.0"
+      version               = "~> 4.0"
       configuration_aliases = [aws.primary, aws.secondary]
     }
   }


### PR DESCRIPTION
## what
* Upgrade aws provider version.

## why
* To keep infra upgraded and avoid version crashes when the module is invoked in an updated environment.

## references
* Terraform documentation [here](https://www.terraform.io/language/modules/develop/providers#provider-version-constraints-in-modules)

