### PR TITLE
Enhancement | Allow custom name for S3 Bucket Replication Name and IAM Role/Policy Replication by variable

### DIFF
--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "replication_bucket" {
   count = var.bucket_replication_enabled ? 1 : 0
 
   provider = aws.secondary
-  bucket   = format("%s-%s-%s-replica", var.namespace, var.stage, var.name)
+  bucket   = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_name)
 
   versioning {
     enabled = true
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "bucket_replication" {
   count = var.bucket_replication_enabled ? 1 : 0
 
   provider = aws.primary
-  name     = format("%s-%s-%s-bucket-replication-module", var.namespace, var.stage, var.name)
+  name     = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_role_name)
   policy   = <<POLICY
 {
   "Version": "2012-10-17",

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "bucket_replication" {
   count = var.bucket_replication_enabled ? 1 : 0
 
   provider           = aws.primary
-  name               = format("%s-%s-%s-bucket-replication-module", var.namespace, var.stage, var.name)
+  name               = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_name_suffix)
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "bucket_replication" {
   count = var.bucket_replication_enabled ? 1 : 0
 
   provider = aws.primary
-  name     = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_role_name)
+  name     = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_name_suffix)
   policy   = <<POLICY
 {
   "Version": "2012-10-17",

--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,7 @@ variable "bucket_replication_name" {
 
 variable "bucket_replication_role_name" {
   type        = string
-  default     = "bucket-replication-module"
+  default     = "bucket-replication"
   description = "Set custom IAM Role name for S3 Bucket Replication"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,18 @@ variable "bucket_replication_enabled" {
   default     = false
 }
 
+variable "bucket_replication_name" {
+  type        = string
+  default     = "replica"
+  description = "Set custom name for S3 Bucket Replication"
+}
+
+variable "bucket_replication_role_name" {
+  type        = string
+  default     = "bucket-replication-module"
+  description = "Set custom IAM Role name for S3 Bucket Replication"
+}
+
 variable "enforce_ssl_requests" {
   type        = bool
   description = "Enable/Disable replica for S3 bucket (for cross region replication purpose)"

--- a/variables.tf
+++ b/variables.tf
@@ -136,10 +136,10 @@ variable "bucket_replication_name" {
   description = "Set custom name for S3 Bucket Replication"
 }
 
-variable "bucket_replication_role_name" {
+variable "bucket_replication_name_suffix" {
   type        = string
   default     = "bucket-replication"
-  description = "Set custom IAM Role name for S3 Bucket Replication"
+  description = "Set custom suffix for S3 Bucket Replication IAM Role/Policy"
 }
 
 variable "enforce_ssl_requests" {


### PR DESCRIPTION
## what
- Adding variables to customize S3 bucket replication and related IAM function/policy
  - Set default value for variable "bucket_replication_name" => "replica"
  - Set default value for variable "bucket_replication_name_suffix" => "bucket-replication"

## why
- Because with the suffix "bucket-replication-module" it was close to the maximum length for bucket names (63 max) => https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
- To be able to handle it via variable and be backward compatible.
- Also the role name has max length of 64 => https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html