### PR TITLE
refactor: eliminate warnings and support v4 of the AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ No modules.
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | Bucket access logging configuration. | <pre>object({<br>    bucket_name = string<br>    prefix      = string<br>  })</pre> | `null` | no |
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `false` | no |
+| <a name="input_mfa_serial"></a> [mfa\_serial](#input\_mfa\_serial) | The serial number of the MFA device to use when deleting versions of S3 objects. Necessary if `mfa_delete` is true. | `string` | `""` | no |
+| <a name="input_mfa_secret"></a> [mfa\_secret](#input\_mfa\_secret) | The number displayed on the MFA device. Necessary if `mfa_delete` is true. | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `"terraform"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | DynamoDB read capacity units | `number` | `5` | no |

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ We have a tfstate S3 Bucket per account
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | ~> 3.0 |
-| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | ~> 3.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | ~> 4.0 |
+| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | ~> 4.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -4,10 +4,6 @@ resource "aws_s3_bucket" "replication_bucket" {
   provider = aws.secondary
   bucket   = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_name)
 
-  versioning {
-    enabled = true
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -19,6 +15,15 @@ resource "aws_s3_bucket" "replication_bucket" {
   tags = {
     Terraform   = "true"
     Environment = var.stage
+  }
+}
+
+resource "aws_s3_bucket_versioning" "replication_bucket" {
+  count  = var.bucket_replication_enabled ? 1 : 0
+  bucket = aws_s3_bucket.replication_bucket[0].id
+
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/bucket_replication.tf
+++ b/bucket_replication.tf
@@ -4,17 +4,20 @@ resource "aws_s3_bucket" "replication_bucket" {
   provider = aws.secondary
   bucket   = format("%s-%s-%s-%s", var.namespace, var.stage, var.name, var.bucket_replication_name)
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
   tags = {
     Terraform   = "true"
     Environment = var.stage
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+  count = var.bucket_replication_enabled ? 1 : 0
+  bucket = aws_s3_bucket.replication_bucket[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,6 @@ resource "aws_s3_bucket" "default" {
   acl           = var.acl
   force_destroy = var.force_destroy
 
-  versioning {
-    enabled    = true
-    mfa_delete = var.mfa_delete
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -50,6 +45,17 @@ resource "aws_s3_bucket" "default" {
   }
 
   depends_on = [aws_s3_bucket.replication_bucket]
+}
+
+resource "aws_s3_bucket_versioning" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  versioning_configuration {
+    status     = "Enabled"
+    mfa_delete = var.mfa_delete ? "Enabled" : "Disabled"
+  }
+
+  mfa = var.mfa_delete ? "${var.mfa_serial} ${var.mfa_secret}" : null
 }
 
 resource "aws_s3_bucket_public_access_block" "default" {

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,14 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  bucket = aws_s3_bucket.default.id
-  acl    = var.acl
+  provider = aws.primary
+  bucket   = aws_s3_bucket.default.id
+  acl      = var.acl
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
-  bucket = aws_s3_bucket.default.id
+  provider = aws.primary
+  bucket   = aws_s3_bucket.default.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -54,7 +56,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
 }
 
 resource "aws_s3_bucket_versioning" "default" {
-  bucket = aws_s3_bucket.default.id
+  provider = aws.primary
+  bucket   = aws_s3_bucket.default.id
 
   versioning_configuration {
     status     = "Enabled"

--- a/main.tf
+++ b/main.tf
@@ -5,14 +5,6 @@ resource "aws_s3_bucket" "default" {
   acl           = var.acl
   force_destroy = var.force_destroy
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
   dynamic "replication_configuration" {
     for_each = var.bucket_replication_enabled ? ["true"] : []
     content {
@@ -45,6 +37,16 @@ resource "aws_s3_bucket" "default" {
   }
 
   depends_on = [aws_s3_bucket.replication_bucket]
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_versioning" "default" {

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ resource "aws_s3_bucket" "default" {
   provider = aws.primary
 
   bucket        = format("%s-%s-%s", var.namespace, var.stage, var.name)
-  acl           = var.acl
   force_destroy = var.force_destroy
 
   dynamic "replication_configuration" {
@@ -37,6 +36,11 @@ resource "aws_s3_bucket" "default" {
   }
 
   depends_on = [aws_s3_bucket.replication_bucket]
+}
+
+resource "aws_s3_bucket_acl" "default" {
+  bucket = aws_s3_bucket.default.id
+  acl    = var.acl
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,18 @@ variable "mfa_delete" {
   default     = false
 }
 
+variable "mfa_serial" {
+  type        = string
+  description = "The serial number of the MFA device to use. Necessary when mfa_delete is true."
+  default     = ""
+}
+
+variable "mfa_secret" {
+  type        = string
+  description = "The numbers displayed on the MFA device when applying. Necessary when mfa_delete is true."
+  default     = ""
+}
+
 variable "enable_server_side_encryption" {
   type        = bool
   description = "Enable DynamoDB server-side encryption"


### PR DESCRIPTION
Hi there! This PR seeks to eliminate warnings when using version 4.0 of the AWS provider. By using new resources, it also removes support for version 3.0 of the AWS provider.

## what

* Version 4 of the AWS provider should no longer yield warnings.
* Version 3 of the AWS provider is no longer supported.

## why

* Version 4 of the AWS provider will be maintained for the foreseeable future.
* Version 4 of the AWS provider deprecated some argument blocks in the
  `aws_s3_bucket` resource, and added resources to replace them.

## references

* [Terraform AWS Provider Version 4 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade)
* Closes #15.

