### PR TITLE
feat: automatically generate backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ No modules.
 | <a name="input_acl"></a> [acl](#input\_acl) | The canned ACL to apply to the S3 bucket | `string` | `"private"` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to each tag map | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `state`) | `list(string)` | <pre>[<br>  "state"<br>]</pre> | no |
+| <a name="input_backend_config_filename"></a> [backend\_config\_filename](#input\_backend\_config\_filename) | Name of the backend configuration file to generate. | `string` | `"backend.tf"` | no |
+| <a name="input_backend_config_filepath"></a> [backend\_config\_filepath](#input\_backend\_config\_filepath) | Directory where the backend configuration file should be generated. | `string` | `""` | no |
+| <a name="input_backend_config_profile"></a> [backend\_config\_profile](#input\_backend\_config\_profile) | AWS profile to use when interfacing the backend infrastructure. | `string` | `""` | no |
+| <a name="input_backend_config_role_arn"></a> [backend\_config\_role\_arn](#input\_backend\_config\_role\_arn) | ARN of the AWS role to assume when interfacing the backend infrastructure, if any. | `string` | `""` | no |
+| <a name="input_backend_config_state_file"></a> [backend\_config\_state\_file](#input\_backend\_config\_state\_file) | Name of the state file in the S3 bucket to use. | `string` | `"terraform.tfstate"` | no |
+| <a name="input_backend_config_template_file"></a> [backend\_config\_template\_file](#input\_backend\_config\_template\_file) | Path to the template file to use when generating the backend configuration. | `string` | `""` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `false` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
 | <a name="input_bucket_replication_enabled"></a> [bucket\_replication\_enabled](#input\_bucket\_replication\_enabled) | Enable/Disable replica for S3 bucket (for cross region replication purpose) | `bool` | `false` | no |
@@ -160,6 +166,32 @@ module "terraform_state_backend" {
   }
 }
 ```
+
+### Generating the backend configuration automatically
+
+If you choose to include this module in your own Terraform configuration to
+provision the backend supporting infrastructure, you can generate the backend
+configuration file automatically with this module.
+
+To do so, use this module as usual, but provide at least the following input:
+
+- `backend_config_filepath = "."`
+
+By default, this will make it so a `backend.tf` file with the backend
+configuration is generated in the current working directory. Once you have
+provisioned the infrastructure with `terraform init && terraform apply`, you
+can copy over Terraform's state file to the backend bucket with the following
+command:
+
+```bash
+terraform init -force-copy
+```
+
+Afterwards, your Terraform state will have been copied over to the S3 bucket
+and Terraform is now ready to use it as a backend.
+
+Refer to the list of `backend_config_*` inputs for more information on how to
+tailor this behavior to your use case.
 
 ---
 

--- a/backend_config.tf
+++ b/backend_config.tf
@@ -1,0 +1,27 @@
+locals {
+  backend_config_template_file = coalesce(var.backend_config_template_file, "${path.module}/templates/backend.tf.tpl")
+}
+
+data "aws_region" "current" {
+  provider = aws.primary
+}
+
+resource "local_file" "backend_config" {
+  count           = var.backend_config_filepath != "" ? 1 : 0
+  filename        = "${var.backend_config_filepath}/${var.backend_config_filename}"
+  file_permission = "0644"
+
+  content = templatefile(local.backend_config_template_file, {
+    region     = data.aws_region.current.name
+    bucket     = aws_s3_bucket.default.id
+    encrypt    = var.enable_server_side_encryption
+    profile    = var.backend_config_profile
+    role_arn   = var.backend_config_role_arn
+    state_file = var.backend_config_state_file
+
+    dynamodb_table = one(coalescelist(
+      aws_dynamodb_table.with_server_side_encryption.*.id,
+      aws_dynamodb_table.without_server_side_encryption.*.id,
+    ))
+  })
+}

--- a/templates/backend.tf.tpl
+++ b/templates/backend.tf.tpl
@@ -1,0 +1,13 @@
+terraform {
+  backend "s3" {
+    region         = "${region}"
+    bucket         = "${bucket}"
+    key            = "${state_file}"
+    %{~ if dynamodb_table != "" ~}
+    dynamodb_table = "${dynamodb_table}"
+    %{~ endif ~}
+    profile        = "${profile}"
+    role_arn       = "${role_arn}"
+    encrypt        = "${encrypt}"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -183,3 +183,39 @@ variable "dynamodb_monitoring" {
   description = "DynamoDB monitoring settings."
   default     = {}
 }
+
+variable "backend_config_template_file" {
+  type        = string
+  description = "Path to the template file to use when generating the backend configuration."
+  default     = ""
+}
+
+variable "backend_config_filepath" {
+  type        = string
+  description = "Directory where the backend configuration file should be generated."
+  default     = ""
+}
+
+variable "backend_config_filename" {
+  type        = string
+  description = "Name of the backend configuration file to generate."
+  default     = "backend.tf"
+}
+
+variable "backend_config_profile" {
+  type        = string
+  description = "AWS profile to use when interfacing the backend infrastructure."
+  default     = ""
+}
+
+variable "backend_config_role_arn" {
+  type        = string
+  description = "ARN of the AWS role to assume when interfacing the backend infrastructure, if any."
+  default     = ""
+}
+
+variable "backend_config_state_file" {
+  type        = string
+  description = "Name of the state file in the S3 bucket to use."
+  default     = "terraform.tfstate"
+}


### PR DESCRIPTION
## what

* Adds a `local_file` resource to (optionally) generate the Terraform backend
  configuration automatically in a new `.tf` file.
* When using this in existing Terraform configuration, the "backend bootstrap"
  steps have been documented in the README.

## why

* Keeping track of the state of the backend supporting infrastructure is
  important, and shouldn't be done locally. With this change, it's possible to
  keep track of it alongside every other provisioned resource in the same place.

## references

* This mimics a feature of the [cloudposse][cloudposse] backend module.

[cloudposse]: https://github.com/cloudposse/terraform-aws-tfstate-backend
